### PR TITLE
update link for kube-aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generic library for building a Kubernetes aggregated API server.
 
 This library contains code to create Kubernetes aggregation server complete with delegated authentication and authorization, 
 `kubectl` compatible discovery information, optional admission chain, and versioned types.  It's first comsumers are
-`k8s.io/kubernetes`, `k8s.io/kubernetes/cmd/kube-aggregator`, and `github.com/kubernetes-incubator/service-catalog`.
+`k8s.io/kubernetes`, `k8s.io/kube-aggregator`, and `github.com/kubernetes-incubator/service-catalog`.
 
 
 ## Compatibility
@@ -26,4 +26,5 @@ Code changes are made in that location, merged into `k8s.io/kubernetes` and late
 ## Things you should *NOT* do
 
  1. Directly modify any files under `pkg` in this repo.  Those are driven from `k8s.io/kuberenetes/staging/src/k8s.io/apiserver`.
- 2. Expect compatibility.  This repo is changing quickly in direct support of Kubernetes and the API isn't yet stable enough for API guarantees.
+ 2. Expect compatibility.  This repo is changing quickly in direct support of
+    Kubernetes and the API isn't yet stable enough for API guarantees.


### PR DESCRIPTION
README is not present in staging, so I guessed to update it here directly.

 - kube-aggregator was split out into a separate top-level repo.
 - my editor added a newline to the end of the file, so I reformatted the paragaph to fit in 80 columns.