### PR TITLE
Fallback to first type if having candidates

### DIFF
--- a/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -282,6 +282,12 @@ func NegotiateMediaTypeOptions(header string, accepted []AcceptedMediaType, endp
 		}
 	}
 
+	if len(accepted) > 0 {
+		return MediaTypeOptions{
+			Accepted: &accepted[0],
+		}, true
+	}
+
 	return MediaTypeOptions{}, false
 }
 


### PR DESCRIPTION
Before giving up to get the most appropriate content type,
this makes the method returns the first type if having some
candidates.

Sorry, we do not accept changes directly against this repository. Please see 
CONTRIBUTING.md for information on where and how to contribute instead.
