### PR TITLE
Migrate apiserver to registry.k8s.io

### DIFF
--- a/pkg/server/options/tracing_test.go
+++ b/pkg/server/options/tracing_test.go
@@ -144,7 +144,7 @@ spec:
         k8s-app: agent
     spec:
       containers:
-        - image: k8s.gcr.io/busybox
+        - image: registry.k8s.io/busybox
           name: agent
 `,
 			expectedResult: nil,


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/4738
